### PR TITLE
Benchmark using latest `typescript-json`

### DIFF
--- a/typescript/benchmark-JSON-msgpack.md
+++ b/typescript/benchmark-JSON-msgpack.md
@@ -1,0 +1,27 @@
+
+> typescript@1.0.0 benchmark
+> npx ttsc && node ./dist/benchmark-JSON-msgpack
+
+operation                                                 |   op   |   ms  |  op/s 
+--------------------------------------------------------- | -----: | ----: | -----:
+buf = Buffer(JSON.stringify(obj));                        | 1244500 | 10000 | 124450
+obj = JSON.parse(buf);                                    | 1568800 | 10000 | 156880
+| | | |
+buf = JSON.stringify(obj);                                | 1829700 | 10000 | 182970
+obj = JSON.parse(buf);                                    | 3287000 | 10000 | 328700
+| | | |
+buf = Buffer(TSON.stringify(obj));                        | 1502800 | 10000 | 150280
+obj = JSON.parse(buf);                                    | 1576300 | 10000 | 157630
+| | | |
+buf = TSON.stringify(obj);                                | 2573800 | 10000 | 257380
+obj = JSON.parse(buf);                                    | 3361900 | 10000 | 336190
+| | | |
+buf = require("msgpackr").pack(obj);                      | 4007600 | 10000 | 400760
+obj = require("msgpackr").unpack(buf);                    | 1470000 | 10000 | 147000
+| | | |
+buf = require("cbor_x").encode(obj);                      | 4051000 | 10000 | 405100
+obj = require("cbor_x").decode(buf);                      | 1602200 | 10000 | 160220
+| | | |
+buf = require("notepack").encode(obj);                    | 1888900 | 10000 | 188890
+obj = require("notepack").decode(buf);                    | 1062700 | 10000 | 106270
+ 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsc && node dist/app.js",
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "benchmark": "npx ts-node -C ttypescript ./src/benchmark-JSON-msgpack.ts"
+    "benchmark": "npx ttsc && node ./dist/benchmark-JSON-msgpack"
   },
   "keywords": [],
   "author": "",
@@ -23,6 +23,6 @@
     "tslint": "^6.1.3",
     "ttypescript": "^1.5.13",
     "typescript": "^4.7.4",
-    "typescript-json": "^3.3.0"
+    "typescript-json": "^3.3.31"
   }
 }

--- a/typescript/src/benchmark-JSON-msgpack.ts
+++ b/typescript/src/benchmark-JSON-msgpack.ts
@@ -46,7 +46,7 @@ import TSON from "typescript-json";
 import { decode, encode } from 'cbor-x';
 
 var pkg = require("../package.json");
-var data = require("./test/example");
+var data = require(__filename.substr(-2) === "ts" ? "./test/example" : "../src/test/example");
 // var packed = msgpack_lite.encode(data);
 var expected = JSON.stringify(data);
 


### PR DESCRIPTION
A little bit faster by https://github.com/samchon/typescript-json/issues/342 implementation.

Anyway, as you can see from the newer benchmark result, the `any` type makes `TSON.stringify()` slower and vulnerable.